### PR TITLE
Blocked clang to max version 14 for os-major  gt/eq 11 lt/eq 22

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -26,9 +26,9 @@ if {${os.major} >= 11 || ${os.platform} ne "darwin"} {
             lappend compilers macports-clang-17
         }
     }
-    lappend compilers macports-clang-16 \
-                      macports-clang-15 \
-                      macports-clang-14
+    lappend compilers macports-clang-14 \
+                      macports-clang-13 \
+                      macports-clang-12
     if {${os.major} < 23 || ${os.platform} ne "darwin"} {
         # https://trac.macports.org/ticket/68257
         # Versions of clang older than clang-14 probably have build issues on


### PR DESCRIPTION
 On macos between 11 and 22 there are build issues with clang
 greater then version 16 according ticket :
 https://trac.macports.org/ticket/68640
 On macos 10.13.16 I found out that the problems started as from the use of
 clang 15.See ticket build of gjs error:
 https://trac.macports.org/ticket/69603
 Other build issues do appear also as from the use of clang 15
 See ticket build of totem :
 https://trac.macports.org/ticket/69594
 By this last build failes when installing with docs during install phase. What happened is that
 a binary totem-scan was build during the install of gtk-docs this scan is runned as check.
 the totem-scan does cause a crash with segfault 11.
 Building without gtk-docs result in ok build and install.
 Totem however crashes at start with segfault 11.
 When building the port with clang 14 all runs fine totem woks fine.
 So long a real solution is not found to work with clang higher then 14
 limiting the clang versions used to 14 will be the only way to build those packages.

 Changes to be committed:
	modified:   _resources/port1.0/compilers/clang_compilers.tcl

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6
Xcode x.y / Command Line Tools 10.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
